### PR TITLE
Made embedded Stethoscope work again 

### DIFF
--- a/Classes/synthDefAutogui.sc
+++ b/Classes/synthDefAutogui.sc
@@ -33,7 +33,7 @@ SynthDefAutogui {
 			}
 		};
 		
-		scopeOn = (((GUI.current.name == \CocoaGUI) || (GUI.current.name == \QtGUI)) && (target.server != Server.internal)).not && scopeOn;
+		scopeOn = (((GUI.current.name == \CocoaGUI)) && (target.server != Server.internal)).not && scopeOn;
 
 		synthDef = SynthDefStorage.synthDefDict[name.asSymbol][0]; // fix for SC 3.11+
 		// specs is a dict of controlspecs
@@ -102,11 +102,12 @@ SynthDefAutogui {
 			window.front 
 		} ;
 		// if you want scope, we put it
-		// stethoscope bounds not as expected, solved with a trick 
+		// the new stethoscope (the one with scrollbars) only works with layouts,
+		// but not with decorator; todo: redo the whole ui wiht layout, really --avdrd
 		if (scopeOn)
 			{
-			composite = CompositeView.new(window, Rect(mrg+hOff, mrg+vOff, step*3, h*5.5));
-			composite.decorator = FlowLayout(composite.bounds);
+			composite = View.new(window, Rect(mrg+hOff, mrg+vOff, step*3, h*5.5));
+			composite.layout = VLayout().margins_([0, 0, 0, 0]);
 			stetho = Stethoscope.new(target.server, 1, rate:rate, view: composite) ;
 			};
 			

--- a/Classes/synthDefAutogui.sc
+++ b/Classes/synthDefAutogui.sc
@@ -35,7 +35,7 @@ SynthDefAutogui {
 		
 		scopeOn = (((GUI.current.name == \CocoaGUI) || (GUI.current.name == \QtGUI)) && (target.server != Server.internal)).not && scopeOn;
 
-		synthDef = SynthDefStorage.synthDefDict[name.asString][0];
+		synthDef = SynthDefStorage.synthDefDict[name.asSymbol][0]; // fix for SC 3.11+
 		// specs is a dict of controlspecs
 		// we need to access it, so better having a void one
 		if (specs.isNil) { specs = SynthDescLib.global[name.asSymbol].tryPerform(\metadata).tryPerform(\at,\specs) };

--- a/Classes/synthDefStorageExt.sc
+++ b/Classes/synthDefStorageExt.sc
@@ -7,6 +7,7 @@
 			this.initBuild;
 			this.buildUgenGraph(ugenGraphFunc, rates, prependArgs);
 			this.finishBuild;
+			func = ugenGraphFunc;
 		} {
 			UGen.buildSynthDef = nil;
 		} ;

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# autogui
+Easy, automatic creation of GUIs for controlling/monitoring Synths and SynthDefs, e.g. `aSynth.autogui`.
+
+Original SynthDefAutogui by Andrea Valle, 2010.
+
+ControlSpec GUI by Martin Marier. Many improvements and bug fixes by Miguel Negrao.
+
+Bug fixes for SC 3.11-3.12.1 by Avid Reader.


### PR DESCRIPTION
I'm not entirely sure why it was turned off some 12 years ago. By the look of the code, the authors had perhaps not figured out that the (then) new Stethoscope only works with layouts, but not with decorator. (With the latter it just displays a black box.) Something to do with the way it paints its own elements internally. 
